### PR TITLE
Use third-party package for SafeAreaView to fix jitter issue

### DIFF
--- a/examples/react-native/react-native-iterate-example/ios/Podfile.lock
+++ b/examples/react-native/react-native-iterate-example/ios/Podfile.lock
@@ -187,6 +187,8 @@ PODS:
   - React-jsinspector (0.63.4)
   - react-native-encrypted-storage (4.0.1):
     - React-Core
+  - react-native-safe-area-context (3.1.9):
+    - React-Core
   - react-native-webview (11.2.3):
     - React-Core
   - React-RCTActionSheet (0.63.4):
@@ -270,6 +272,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - react-native-encrypted-storage (from `../node_modules/react-native-encrypted-storage`)
+  - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-webview (from `../node_modules/react-native-webview`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
@@ -320,6 +323,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-encrypted-storage:
     :path: "../node_modules/react-native-encrypted-storage"
+  react-native-safe-area-context:
+    :path: "../node_modules/react-native-safe-area-context"
   react-native-webview:
     :path: "../node_modules/react-native-webview"
   React-RCTActionSheet:
@@ -363,6 +368,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
   react-native-encrypted-storage: 372c21fbf21157fc67fe62c39212dbe01dc74ade
+  react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94
   react-native-webview: 6520e3e7b4933de76b95ef542c8d7115cf45b68e
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
@@ -378,4 +384,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: e878d7c03f2243dec40d439fcfd682fd221c5a12
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1

--- a/examples/react-native/react-native-iterate-example/package.json
+++ b/examples/react-native/react-native-iterate-example/package.json
@@ -14,6 +14,7 @@
     "react": "^17.0.1",
     "react-native": "0.63.4",
     "react-native-encrypted-storage": "^4.0.1",
+    "react-native-safe-area-context": "^3.1.9",
     "react-native-webview": "^11.2.3",
     "react-redux": "^7.2.2",
     "redux": "^4.0.5"

--- a/examples/react-native/react-native-iterate-example/src/react-native-iterate/src/components/Prompt/index.js
+++ b/examples/react-native/react-native-iterate-example/src/react-native-iterate/src/components/Prompt/index.js
@@ -7,7 +7,6 @@ import React, {useCallback, useEffect, useRef} from 'react';
 import {
   Animated,
   Image,
-  SafeAreaView,
   StyleSheet,
   Text,
   useColorScheme,
@@ -17,6 +16,7 @@ import {
   View,
 } from 'react-native';
 import {connect} from 'react-redux';
+import {SafeAreaView} from 'react-native-safe-area-context';
 
 import {Platforms, Themes} from '../../constants';
 import type {State} from '../../redux';
@@ -88,7 +88,7 @@ const Prompt: (Props) => React$Node = ({
           ...styles.prompt,
           backgroundColor: colorScheme === Themes.Dark ? '#000' : '#fff',
         }}>
-        <SafeAreaView>
+        <SafeAreaView edges={['bottom']}>
           <CloseButton onPress={onDismissAnimated} />
           <Text
             // eslint-disable-next-line react-native/no-inline-styles

--- a/examples/react-native/react-native-iterate-example/src/react-native-iterate/src/components/WithIterate.js
+++ b/examples/react-native/react-native-iterate-example/src/react-native-iterate/src/components/WithIterate.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import {View, StyleSheet} from 'react-native';
 import {Provider} from 'react-redux';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
 
 import Iterate, {store} from '../iterate';
 import {
@@ -55,14 +56,16 @@ const withIterate = ({apiKey}: Props) => {
   });
 
   return (Comp: () => React$Node) => (props: {}) => (
-    <View style={styles.container}>
-      <View style={styles.app}>
-        <Comp {...props} />
-        <Provider store={store}>
-          <PromptOrSurvey />
-        </Provider>
+    <SafeAreaProvider>
+      <View style={styles.container}>
+        <View style={styles.app}>
+          <Comp {...props} />
+          <Provider store={store}>
+            <PromptOrSurvey />
+          </Provider>
+        </View>
       </View>
-    </View>
+    </SafeAreaProvider>
   );
 };
 

--- a/examples/react-native/react-native-iterate-example/yarn.lock
+++ b/examples/react-native/react-native-iterate-example/yarn.lock
@@ -5353,6 +5353,11 @@ react-native-encrypted-storage@^4.0.1:
   resolved "https://registry.yarnpkg.com/react-native-encrypted-storage/-/react-native-encrypted-storage-4.0.1.tgz#9f36344634e01343c387771923a2ca0228a07fdc"
   integrity sha512-RQf5lbAWNYhAtUbm5eh3eT1TTdH+kL0Mjpv9zImANLnAEoH6ZtqDmIXF+m/E5uAF5d2DN3J0KMh7i2KNPG0JJQ==
 
+react-native-safe-area-context@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.9.tgz#48864ea976b0fa57142a2cc523e1fd3314e7247e"
+  integrity sha512-wmcGbdyE/vBSL5IjDPReoJUEqxkZsywZw5gPwsVUV1NBpw5eTIdnL6Y0uNKHE25Z661moxPHQz6kwAkYQyorxA==
+
 react-native-webview@^11.2.3:
   version "11.2.3"
   resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.2.3.tgz#1b82685ab60645d4161f2e25e98286493cdffa5d"


### PR DESCRIPTION
I did a fair amount of digging into what was causing the prompt to jitter, and while I found a handful of other people experiencing the problem, I didn't find a consistent explanation. The consensus was that this is an issue with the react-native SafeAreaView component, but that a couple of third-party implementations of SafeAreaView didn't have this issue. I tried the most popular one, and it does fix the problem.