### PR TITLE
Require the user to provide their own storage facility

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,24 +33,47 @@ $ npm install --save react-native-iterate
 
 **Install peer dependencies**
 
-We rely on three popular peer dependencies, if you already have them in your app you can skip this step
+We rely on two popular peer dependencies, if you already have them in your app you can skip this step.
 
 - [react-native-webview](https://github.com/react-native-webview/react-native-webview) - used to display the survey
 - [react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context) - used to layout the survey using the native safe area
-- [react-native-encrypted-storage](https://github.com/emeraldsanto/react-native-encrypted-storage) - used to securely store the API key and user properties
 
 With yarn
 
 ```
-$ yarn add react-native-encrypted-storage react-native-safe-area-context react-native-webview
+$ yarn add react-native-safe-area-context react-native-webview
 ```
 
 With npm
 
 ```
-$ npm install --save react-native-encrypted-storage react-native-safe-area-context react-native-webview
+$ npm install --save react-native-safe-area-context react-native-webview
 ```
 
+**Install storage facility**
+
+When you initialize Iterate you provide it with a storage facility that's used to save the API key as well as any additional user data set by calling the `identify` method. We recommend using an encrypted storage facility like [react-native-encrypted-storage](https://github.com/emeraldsanto/react-native-encrypted-storage), however you can also use [async-storage](https://github.com/react-native-async-storage/async-storage) or provide your own, the only requirement is that it complies with our StorageInterface.
+
+```Typescript
+export interface SecureStorage {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+}
+```
+
+Install a storage facility
+
+With yarn
+
+```
+$ yarn add react-native-encrypted-storage
+```
+
+With npm
+
+```
+$ npm install --save react-native-encrypted-storage
+```
 
 **Link native dependencies**
 
@@ -59,9 +82,13 @@ From react-native 0.60 autolinking will take care of the link step and you can s
 React Native modules that include native Objective-C, Swift, Java, or Kotlin code have to be "linked" so that the compiler knows to include them in the app.
 
 ```
-$ react-native link react-native-encrypted-storage
 $ react-native link react-native-safe-area-context
 $ react-native link react-native-webview
+```
+
+Link your storage facility
+```
+$ react-native link react-native-encrypted-storage
 ```
 
 **Install pods**
@@ -86,12 +113,16 @@ Create your [Iterate](https://iteratehq.com) account if you haven't already.
 
 ```JSX
 import Iterate, { withIterate } from 'react-native-iterate';
+import SecureStorage from 'react-native-encrypted-storage';
 
 const App: () => JSX.Element = () => {
     // ...your application component
 }
 
-export default withIterate({ apiKey: YOUR_API_KEY })(App);
+export default withIterate({ 
+    apiKey: YOUR_API_KEY,
+    storage: SecureStorage, 
+})(App);
 ```
 
 4. Implement events

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -185,7 +185,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-encrypted-storage (4.0.1):
+  - react-native-encrypted-storage (4.0.2):
     - React-Core
   - react-native-safe-area-context (3.1.9):
     - React-Core
@@ -251,6 +251,8 @@ PODS:
     - React-Core (= 0.63.4)
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
+  - RNCAsyncStorage (1.14.1):
+    - React-Core
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -284,6 +286,7 @@ DEPENDENCIES:
   - React-RCTText (from `../node_modules/react-native/Libraries/Text`)
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -347,6 +350,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/Vibration"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -367,7 +372,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-encrypted-storage: 372c21fbf21157fc67fe62c39212dbe01dc74ade
+  react-native-encrypted-storage: e78d848ce0fb663c2ce306e37921d026809322e6
   react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94
   react-native-webview: 6520e3e7b4933de76b95ef542c8d7115cf45b68e
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
@@ -380,6 +385,7 @@ SPEC CHECKSUMS:
   React-RCTText: 5c51df3f08cb9dedc6e790161195d12bac06101c
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
+  RNCAsyncStorage: fe58eec522885718d6b297b7b658bf87d7ca557b
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
 PODFILE CHECKSUM: 2cb643ee3fe8f1b973a9bc35e5c3ac77c5fd4a77

--- a/example/package.json
+++ b/example/package.json
@@ -9,9 +9,10 @@
     "start": "react-native start"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.14.1",
     "react": "16.13.1",
     "react-native": "0.63.4",
-    "react-native-encrypted-storage": "^4.0.1",
+    "react-native-encrypted-storage": "^4.0.2",
     "react-native-safe-area-context": "^3.1.9",
     "react-native-webview": "^11.2.3"
   },

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { StyleSheet, View, Text } from 'react-native';
 import Iterate, { withIterate } from 'react-native-iterate';
+import SecureStorage from 'react-native-encrypted-storage';
 
 const App = () => {
   React.useEffect(() => {
@@ -35,4 +36,5 @@ const styles = StyleSheet.create({
 export default withIterate({
   apiKey:
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb21wYW55X2lkIjoiNWRmZTM2OGEwOWI2ZWYwMDAxYjNlNjE4IiwiaWF0IjoxNTc2OTQxMTk0fQ.QBWr2goMwOngVhi6wY9sdFAKEvBGmn-JRDKstVMFh6M',
+  storage: SecureStorage,
 })(App);

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -695,6 +695,13 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@react-native-async-storage/async-storage@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.14.1.tgz#3c2ff2b1a312df3b1c809a60fa88665e50a095b8"
+  integrity sha512-UkLUox2q5DKNYB6IMUzsuwrTJeXGLySvtQlnrqd3fd+96JErCT4X3xD+W1cvQjes0nm0LbaELbwObKc+Tea7wA==
+  dependencies:
+    deep-assign "^3.0.0"
+
 "@react-native-community/cli-debugger-ui@^4.13.1":
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz#07de6d4dab80ec49231de1f1fbf658b4ad39b32c"
@@ -1535,6 +1542,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+deep-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
+  integrity sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
+  dependencies:
+    is-obj "^1.0.0"
+
 deepmerge@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
@@ -2239,6 +2253,11 @@ is-number@^3.0.0:
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
+
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -3356,10 +3375,10 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-encrypted-storage@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-encrypted-storage/-/react-native-encrypted-storage-4.0.1.tgz#9f36344634e01343c387771923a2ca0228a07fdc"
-  integrity sha512-RQf5lbAWNYhAtUbm5eh3eT1TTdH+kL0Mjpv9zImANLnAEoH6ZtqDmIXF+m/E5uAF5d2DN3J0KMh7i2KNPG0JJQ==
+react-native-encrypted-storage@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-encrypted-storage/-/react-native-encrypted-storage-4.0.2.tgz#c7d59b1d3ff2f80d572be3e85aaab3fdee16744a"
+  integrity sha512-vneDkHGDuTvLQjUBztqb2YI8QoH1zxdJonPGTS+g57lfJZff9fAjoLSSb6NgMBebpXFcK3I3sEresGyL+3AArw==
 
 react-native-safe-area-context@^3.1.9:
   version "3.1.9"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-encrypted-storage": "*",
     "react-native-safe-area-context": "*",
     "react-native-webview": "*"
   },

--- a/src/components/WithIterate.tsx
+++ b/src/components/WithIterate.tsx
@@ -14,15 +14,19 @@ import {
   setUserAuthToken,
   setUserTraits,
 } from '../redux';
-import Storage, { Keys } from '../storage';
+import Storage, { Keys, StorageInterface } from '../storage';
 
 import PromptOrSurvey from './PromptOrSurvey';
 
 interface Props {
   apiKey: string;
+  storage: StorageInterface;
 }
 
-const withIterate = ({ apiKey }: Props) => {
+const withIterate = ({ apiKey, storage }: Props) => {
+  // Set the user's secure storage if one was provided
+  Storage.storageProvider = storage;
+
   // Initialize with the company api key
   Iterate.configure(apiKey);
 

--- a/src/storage.tsx
+++ b/src/storage.tsx
@@ -1,4 +1,8 @@
-import EncryptedStorage from 'react-native-encrypted-storage';
+// Interface representing a secure storage facility
+export interface StorageInterface {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+}
 
 export const Keys = {
   lastUpdated: 'last_updated',
@@ -7,34 +11,31 @@ export const Keys = {
 };
 
 class Storage {
+  // A user-provided secure storage
+  storageProvider?: StorageInterface;
+
   get = async (key: string) => {
-    try {
-      const result = await EncryptedStorage.getItem(`com.iteratehq.${key}`);
+    return this.secureStorage().then(async (storage) => {
+      const result = await storage.getItem(`com.iteratehq.${key}`);
       if (result != null) {
         return JSON.parse(result).value;
       }
-    } catch (error) {
-      console.error(error);
-    }
+    });
   };
 
   set = async (key: string, value: any) => {
-    try {
-      await EncryptedStorage.setItem(
-        `com.iteratehq.${key}`,
-        JSON.stringify({ value })
-      );
-    } catch (error) {
-      console.error(error);
-    }
+    return this.secureStorage().then(
+      async (storage) =>
+        await storage.setItem(`com.iteratehq.${key}`, JSON.stringify({ value }))
+    );
   };
 
-  clear = async () => {
-    try {
-      EncryptedStorage.clear();
-    } catch (error) {
-      console.error(error);
+  secureStorage = async (): Promise<StorageInterface> => {
+    if (this.storageProvider != null) {
+      return this.storageProvider;
     }
+
+    throw 'Error initializing Iterate: missing storage. You must provide a storage facility, see README for details';
   };
 }
 


### PR DESCRIPTION
This removes the previous peer dependency of `react-native-encrypted-storage` and instead has the user pass in a storage facility.

Most users will already have a storage facility so this allows them to continue to use that one, and those that don't it's a simple additional dependency.