### PR TITLE
Change withIterate to IterateProvider and accept safe area

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ $ npm install --save react-native-iterate
 
 **Install peer dependencies**
 
-We rely on two popular peer dependencies, if you already have them in your app you can skip this step.
+We rely on only one peer dependency, if you already have it in your app you can skip this step.
 
 - [react-native-webview](https://github.com/react-native-webview/react-native-webview) - used to display the survey
-- [react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context) - used to layout the survey using the native safe area
 
 With yarn
 
@@ -62,7 +61,6 @@ export interface StorageInterface {
 }
 ```
 
-Install a storage facility
 
 With yarn
 
@@ -76,6 +74,23 @@ With npm
 $ npm install --save react-native-encrypted-storage
 ```
 
+**Install safe area provider**
+
+On mobile devices the safe area represents the portion of the view that is suitable for UI to be displayed. Rather than requiring an additional peer dependency, you pass in your own method of providing the safe area. We recommend you use [react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context), however you can provide your own method that conforms to the interface `() => {top: number, bottom: number, left: number, right: number}`
+
+
+With yarn
+
+```
+$ yarn add react-native-safe-area-context
+```
+
+With npm
+
+```
+$ npm install --save react-native-safe-area-context
+```
+
 **Link native dependencies**
 
 From react-native 0.60 autolinking will take care of the link step and you can safely skip
@@ -83,13 +98,17 @@ From react-native 0.60 autolinking will take care of the link step and you can s
 React Native modules that include native Objective-C, Swift, Java, or Kotlin code have to be "linked" so that the compiler knows to include them in the app.
 
 ```
-$ react-native link react-native-safe-area-context
 $ react-native link react-native-webview
 ```
 
 Link your storage facility
 ```
 $ react-native link react-native-encrypted-storage
+```
+
+Link your safe area provider
+```
+$ react-native link react-native-safe-area-context
 ```
 
 **Install pods**
@@ -115,15 +134,17 @@ Create your [Iterate](https://iteratehq.com) account if you haven't already.
 ```JSX
 import Iterate, { withIterate } from 'react-native-iterate';
 import SecureStorage from 'react-native-encrypted-storage';
+import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 
-const App = () => {
-    // ...your application component
-}
+const App = () => (
+    <SafeAreaProvider>
+        <IterateProvider apiKey={YOUR_API_KEY} safeArea={useSafeAreaInsets} storage={SecureStorage}>
+          { // Your application views }
+        </IterateProvider>
+    </SafeAreaProvider>
+)
 
-export default withIterate({ 
-    apiKey: YOUR_API_KEY,
-    storage: SecureStorage, 
-})(App);
+export default App;
 ```
 
 4. Implement events

--- a/README.md
+++ b/README.md
@@ -129,20 +129,30 @@ Create your [Iterate](https://iteratehq.com) account if you haven't already.
 
 1. Create a new survey and select "Install in your mobile app"
 2. Go to the "Preview & Publish" tab and copy your SDK API key
-3. Wrap your App in the `withIterate` higher-order component
+3. Call Iterate.Init with your apiKey, safeArea, and storage, then wrap your App in the `<SafeAreaProvider>` (if using react-native-safe-area-context) and `<IterateProvider>` components
 
 ```JSX
 import Iterate, { withIterate } from 'react-native-iterate';
 import SecureStorage from 'react-native-encrypted-storage';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 
-const App = () => (
+const App = () => {
+  React.useEffect(() => {
+    Iterate.init({
+      apiKey: apiKey,
+      safeArea: useSafeAreaInsets,
+      storage: SecureStorage,
+    });
+  }, []);
+
+  return (
     <SafeAreaProvider>
-        <IterateProvider apiKey={YOUR_API_KEY} safeArea={useSafeAreaInsets} storage={SecureStorage}>
-          { // Your application views }
-        </IterateProvider>
+      <IterateProvider>
+        { // Your application views }
+      </IterateProvider>
     </SafeAreaProvider>
-)
+  )
+}
 
 export default App;
 ```
@@ -169,17 +179,13 @@ const ActivityFeed = () => {
 
 You'll likely want to preview your survey before publishing it so you can test that everything works correctly. When previewing a survey you'll be able to see a survey before it's published. When previewing a survey all targeting options for that survey are ignored (e.g. rate limiting, targeting user properties), the only thing you need to do is trigger the event that your survey is targeting and it will show up.
 
-1. In the "Preview & Publish" tab select 'Learn more' and copy the code.
+1. In the "Preview & Publish" tab select 'React Native' and copy the preview code.
 2. Implement into your application, this can be done once in any component that's rendered before the event you're targeting
 
 ```JSX
-    const App = () => {
-        useEffect(() => {
-            Iterate.preview('your-survey-id');
-        }, []);
-
-        // ...your application component
-    }
+useEffect(() => {
+  Iterate.preview('your-survey-id');
+}, []);
 ```
 
 ## Recommendations
@@ -191,38 +197,24 @@ When implementing Iterate for the first time, we encourage you to implement even
 Using the `identify` method, you can easily add 'user properties' to a user that can be used to target surveys to them and associate the information with all of their future responses.
 
 ```JSX
-    const App = () => {
-        useEffect(() => {
-            Iterate.identify({
-                email: 'example@email.com',
-                user_id: 123456,
-                is_subscriber: true,
-            });
-        }, []);
-
-        // ...your application component
-    }
+useEffect(() => {
+  Iterate.identify({
+    email: 'example@email.com',
+    user_id: 123456,
+    is_subscriber: true,
+  });
+}, []);
 ```
 
-You can also associated 'response properties' with the user's responses to a specific survey (not associated with any future surveys they fill out), by passing a second data object to the `identify` method.
+You can also associate 'response properties' with the user's responses to a specific survey (not associated with any future surveys they fill out), by passing an object to the `sendEvent` method.
 
 ```JSX
-    const App = () => {
-        useEffect(() => {
-            Iterate.identify({
-                // User properties
-                email: 'example@email.com',
-                user_id: 123456,
-                is_subscriber: true,
-            },{
-                // Event properties
-                selected_product_id: 12345,
-                timestamp: 140002658477
-            });
-        }, []);
-
-        // ...your application component
-    }
+useEffect(() => {
+  Iterate.sendEvent('viewed-activity-feed', {
+    selected_product_id: 12345,
+    timestamp: 140002658477
+  });
+}, []);
 ```
 
 
@@ -233,15 +225,11 @@ For more information see our [help article](https://help.iteratehq.com/en/articl
 If you need access to the user's responses on the client, you can use the `onResponse` method to pass a callback function that will return the question and response
 
 ```JSX
-    const App = () => {
-        useEffect(() => {
-            Iterate.onResponse((response, question) => {
-                // Your logic here
-            });
-        }, []);
-
-        // ...your application component
-    }
+useEffect(() => {
+  Iterate.onResponse((response, question) => {
+    // Your logic here
+  });
+}, []);
 ```
 
 ## Clearing data
@@ -249,15 +237,11 @@ If you need access to the user's responses on the client, you can use the `onRes
 To clear all data Iterate has stored (user api key, any user properties stored by calling the `identify` method, etc) call the `reset` method. This is commonly called when you log a user out of your app.
 
 ```JSX
-    const App = () => {
-        const logout = useCallback(() => {
-            Iterate.reset()
+const logout = useCallback(() => {
+  Iterate.reset()
 
-            // Your other logout logic here
-        }, []);
-
-        // ...your application component
-    }
+  // Your other logout logic here
+}, []);
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Create your [Iterate](https://iteratehq.com) account if you haven't already.
 
 1. Create a new survey and select "Install in your mobile app"
 2. Go to the "Preview & Publish" tab and copy your SDK API key
-3. Call Iterate.Init with your apiKey, safeArea, and storage, then wrap your App in the `<SafeAreaProvider>` (if using react-native-safe-area-context) and `<IterateProvider>` components
+3. Call Iterate.Init with your apiKey, safeArea function, and storage, then wrap your App in the `<SafeAreaProvider>` (if using react-native-safe-area-context) and `<IterateProvider>` components
 
 ```JSX
 import Iterate, { withIterate } from 'react-native-iterate';

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 
 import { StyleSheet, View, Text } from 'react-native';
-import Iterate, { withIterate } from 'react-native-iterate';
+import Iterate, { IterateProvider } from 'react-native-iterate';
+import {
+  SafeAreaProvider,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import SecureStorage from 'react-native-encrypted-storage';
 
 const App = () => {
@@ -13,10 +17,21 @@ const App = () => {
     Iterate.sendEvent('show-survey-button-tapped');
   }, []);
 
+  const apiKey =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb21wYW55X2lkIjoiNWRmZTM2OGEwOWI2ZWYwMDAxYjNlNjE4IiwiaWF0IjoxNTc2OTQxMTk0fQ.QBWr2goMwOngVhi6wY9sdFAKEvBGmn-JRDKstVMFh6M';
+
   return (
-    <View style={styles.container}>
-      <Text>Hello</Text>
-    </View>
+    <SafeAreaProvider>
+      <IterateProvider
+        apiKey={apiKey}
+        safeArea={useSafeAreaInsets}
+        storage={SecureStorage}
+      >
+        <View style={styles.container}>
+          <Text>Hello</Text>
+        </View>
+      </IterateProvider>
+    </SafeAreaProvider>
   );
 };
 
@@ -33,8 +48,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default withIterate({
-  apiKey:
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb21wYW55X2lkIjoiNWRmZTM2OGEwOWI2ZWYwMDAxYjNlNjE4IiwiaWF0IjoxNTc2OTQxMTk0fQ.QBWr2goMwOngVhi6wY9sdFAKEvBGmn-JRDKstVMFh6M',
-  storage: SecureStorage,
-})(App);
+export default App;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,11 +10,20 @@ import SecureStorage from 'react-native-encrypted-storage';
 
 const App = () => {
   React.useEffect(() => {
+    Iterate.init({
+      apiKey: apiKey,
+      safeArea: useSafeAreaInsets,
+      storage: SecureStorage,
+    });
     Iterate.onResponse((response, question) => {
       console.log('onResponseCallback', response, question);
     });
 
-    Iterate.sendEvent('show-survey-button-tapped');
+    Iterate.identify({ email: 'example@email.com' });
+
+    Iterate.sendEvent('show-survey-button-tapped', {
+      currentTime: new Date().getTime(),
+    });
   }, []);
 
   const apiKey =
@@ -22,11 +31,7 @@ const App = () => {
 
   return (
     <SafeAreaProvider>
-      <IterateProvider
-        apiKey={apiKey}
-        safeArea={useSafeAreaInsets}
-        storage={SecureStorage}
-      >
+      <IterateProvider>
         <View style={styles.container}>
           <Text>Hello</Text>
         </View>

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "react-native": "0.63.4",
     "react-native-builder-bob": "^0.18.1",
     "react-native-encrypted-storage": "^4.0.2",
-    "react-native-safe-area-context": "^3.1.9",
     "react-native-webview": "^11.2.3",
     "release-it": "^14.4.1",
     "typescript": "^4.1.3"
@@ -78,7 +77,6 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-safe-area-context": "*",
     "react-native-webview": "*"
   },
   "jest": {

--- a/src/components/IterateProvider.tsx
+++ b/src/components/IterateProvider.tsx
@@ -6,65 +6,27 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import Iterate, { store } from '../iterate';
-import {
-  setCompanyAuthToken,
-  setLastUpdated,
-  setUserAuthToken,
-  setUserTraits,
-} from '../redux';
-import Storage, { Keys, StorageInterface } from '../storage';
-import type { EdgeInsets } from '../types';
+import { store } from '../iterate';
+import SafeArea from '../safearea';
 
 import PromptOrSurvey from './PromptOrSurvey';
 
 interface Props {
-  apiKey: string;
   children: React.ReactNode;
-  storage: StorageInterface;
-  safeArea: () => EdgeInsets;
 }
 
-const IterateProvider = ({ apiKey, children, safeArea, storage }: Props) => {
-  // Set the user's secure storage if one was provided
-  Storage.provider = storage;
-
-  // Initialize with the company api key
-  Iterate.configure(apiKey);
-
-  // Initial state values
-  store.dispatch(setCompanyAuthToken(apiKey));
-  Storage.getItem(Keys.authToken).then((authToken?: string) => {
-    Storage.getItem(Keys.lastUpdated).then((lastUpdated?: string) => {
-      Storage.getItem(Keys.userTraits).then((userTraits?: {}) => {
-        // Initialize the api with the user auth token
-        if (authToken != null) {
-          Iterate.configure(authToken);
-          store.dispatch(setUserAuthToken(authToken));
-        }
-
-        // Initialize the last updated timestamp
-        if (lastUpdated != null) {
-          store.dispatch(setLastUpdated(parseInt(lastUpdated, 10)));
-        }
-
-        // Initialize the user traits
-        if (userTraits != null) {
-          store.dispatch(setUserTraits(userTraits));
-        }
-
-        // Let the iterate client know we're all initialized and it's safe
-        // to make the embed request
-        Iterate.init();
-      });
-    });
-  });
+const IterateProvider = ({ children }: Props) => {
+  // Get safe area
+  const safeArea =
+    SafeArea.provider != null
+      ? SafeArea.provider()
+      : { top: 0, right: 0, bottom: 0, left: 0 };
 
   return (
     <>
       {children}
       <Provider store={store}>
-        <PromptOrSurvey safeAreaInsets={safeArea()} />
+        <PromptOrSurvey safeAreaInsets={safeArea} />
       </Provider>
     </>
   );

--- a/src/components/IterateProvider.tsx
+++ b/src/components/IterateProvider.tsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import Iterate, { store } from '../iterate';
 import {
@@ -15,17 +14,20 @@ import {
   setUserTraits,
 } from '../redux';
 import Storage, { Keys, StorageInterface } from '../storage';
+import type { EdgeInsets } from '../types';
 
 import PromptOrSurvey from './PromptOrSurvey';
 
 interface Props {
   apiKey: string;
+  children: React.ReactNode;
   storage: StorageInterface;
+  safeArea: () => EdgeInsets;
 }
 
-const withIterate = ({ apiKey, storage }: Props) => {
+const IterateProvider = ({ apiKey, children, safeArea, storage }: Props) => {
   // Set the user's secure storage if one was provided
-  Storage.storageProvider = storage;
+  Storage.provider = storage;
 
   // Initialize with the company api key
   Iterate.configure(apiKey);
@@ -58,14 +60,14 @@ const withIterate = ({ apiKey, storage }: Props) => {
     });
   });
 
-  return (Comp: () => JSX.Element) => (props: {}) => (
-    <SafeAreaProvider>
-      <Comp {...props} />
+  return (
+    <>
+      {children}
       <Provider store={store}>
-        <PromptOrSurvey />
+        <PromptOrSurvey safeAreaInsets={safeArea()} />
       </Provider>
-    </SafeAreaProvider>
+    </>
   );
 };
 
-export default withIterate;
+export default IterateProvider;

--- a/src/components/Prompt/index.tsx
+++ b/src/components/Prompt/index.tsx
@@ -9,10 +9,10 @@ import {
   PanResponder,
 } from 'react-native';
 import { connect } from 'react-redux';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { State } from '../../redux';
 import { showSurvey } from '../../redux';
+import type { EdgeInsets } from '../../types';
 import type { Survey } from '../../types';
 
 import PromptButton from './Button';
@@ -21,6 +21,7 @@ import type { Dispatch } from 'src/iterate';
 type Props = {
   dispatchShowSurvey: (Survey: Survey) => void;
   onDismiss: () => void;
+  safeAreaInsets: EdgeInsets;
   survey?: Survey;
 };
 
@@ -31,12 +32,11 @@ const DISPLAYED_POSITION = 0;
 const Prompt: (Props: Props) => JSX.Element = ({
   dispatchShowSurvey,
   onDismiss,
+  safeAreaInsets,
   survey,
 }) => {
   const promptAnimation = useRef(new Animated.Value(DISMISSED_POSITION))
     .current;
-
-  const insets = useSafeAreaInsets();
 
   const panResponder = useMemo(
     () =>
@@ -99,7 +99,7 @@ const Prompt: (Props: Props) => JSX.Element = ({
     }, ANIMATION_DURATION);
   }, [dispatchShowSurvey, promptAnimation, survey]);
 
-  const paddingBottom = insets.bottom > 0 ? insets.bottom : 20;
+  const paddingBottom = safeAreaInsets.bottom > 0 ? safeAreaInsets.bottom : 20;
 
   return (
     <Animated.View
@@ -181,7 +181,8 @@ const closeButtonStyles = StyleSheet.create({
   },
 });
 
-const mapStateToProps = ({ survey }: State) => ({
+const mapStateToProps = ({ safeAreaInsets, survey }: State) => ({
+  safeAreaInsets,
   survey,
 });
 

--- a/src/components/PromptOrSurvey.tsx
+++ b/src/components/PromptOrSurvey.tsx
@@ -3,12 +3,13 @@
  * @flow
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import type { State } from '../redux';
-import { dismiss } from '../redux';
+import { dismiss, setSafeAreaInsets } from '../redux';
 import type { Survey } from '../types';
+import type { EdgeInsets } from '../types';
 
 import Iterate, { Dispatch } from '../iterate';
 import Prompt from './Prompt';
@@ -16,6 +17,8 @@ import SurveyView from './Survey';
 
 type Props = {
   dispatchDismiss: () => void;
+  dispatchSafeAreaInsets: (safeAreaInsets: EdgeInsets) => void;
+  safeAreaInsets: EdgeInsets;
   showPrompt: boolean;
   showSurvey: boolean;
   survey?: Survey;
@@ -23,6 +26,8 @@ type Props = {
 
 const PromptOrSurvey: (Props: Props) => JSX.Element | null = ({
   dispatchDismiss,
+  dispatchSafeAreaInsets,
+  safeAreaInsets,
   survey,
   showPrompt,
   showSurvey,
@@ -33,6 +38,12 @@ const PromptOrSurvey: (Props: Props) => JSX.Element | null = ({
       Iterate.api.dismissed(survey);
     }
   }, [dispatchDismiss, survey]);
+
+  useEffect(() => {
+    if (safeAreaInsets != null) {
+      dispatchSafeAreaInsets(safeAreaInsets);
+    }
+  }, [dispatchSafeAreaInsets, safeAreaInsets]);
 
   if (showPrompt) {
     return <Prompt onDismiss={dismissed} />;
@@ -52,6 +63,9 @@ const mapStateToProps = ({ showPrompt, showSurvey, survey }: State) => ({
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   dispatchDismiss: () => {
     dispatch(dismiss());
+  },
+  dispatchSafeAreaInsets: (safeAreaInsets: EdgeInsets) => {
+    dispatch(setSafeAreaInsets(safeAreaInsets));
   },
 });
 

--- a/src/components/Survey.tsx
+++ b/src/components/Survey.tsx
@@ -18,11 +18,12 @@ import { WebView } from 'react-native-webview';
 import { DefaultHost, EventMessageTypes, Themes } from '../constants';
 import Iterate from '../iterate';
 import type { State } from '../redux';
-import type { EventMessage, EventTraits, Survey } from '../types';
+import type { EventMessage, EventTraitsMap, Survey } from '../types';
 
 type Props = {
   companyAuthToken?: string;
-  eventTraits?: EventTraits;
+  displayedSurveyResponseId?: number;
+  eventTraits: EventTraitsMap;
   onDismiss: () => void;
   survey?: Survey;
   userAuthToken?: string;
@@ -30,6 +31,7 @@ type Props = {
 
 const SurveyView: (Props: Props) => JSX.Element = ({
   companyAuthToken,
+  displayedSurveyResponseId,
   eventTraits,
   onDismiss,
   survey,
@@ -46,15 +48,21 @@ const SurveyView: (Props: Props) => JSX.Element = ({
   }
 
   // Add response properties
-  for (const trait in eventTraits) {
-    const value = encodeURIComponent(eventTraits[trait].toString());
+  if (
+    displayedSurveyResponseId != null &&
+    eventTraits[displayedSurveyResponseId] != null
+  ) {
+    const traits = eventTraits[displayedSurveyResponseId];
+    for (const trait in traits) {
+      const value = encodeURIComponent(traits[trait].toString());
 
-    if (typeof eventTraits[trait] === 'boolean') {
-      params.push(`response_boolean_${trait}=${value}`);
-    } else if (typeof eventTraits[trait] === 'number') {
-      params.push(`response_number_${trait}=${value}`);
-    } else {
-      params.push(`response_${trait}=${value}`);
+      if (typeof traits[trait] === 'boolean') {
+        params.push(`response_boolean_${trait}=${value}`);
+      } else if (typeof traits[trait] === 'number') {
+        params.push(`response_number_${trait}=${value}`);
+      } else {
+        params.push(`response_${trait}=${value}`);
+      }
     }
   }
 
@@ -137,10 +145,12 @@ const styles = StyleSheet.create({
 
 const mapStateToProps = ({
   companyAuthToken,
+  displayedSurveyResponseId,
   eventTraits,
   survey,
   userAuthToken,
 }: State) => ({
+  displayedSurveyResponseId,
   eventTraits,
   survey,
   companyAuthToken,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import Iterate from './iterate';
-import withIterate from './components/WithIterate';
+import IterateProvider from './components/IterateProvider';
 import type { StorageInterface } from './storage';
 
 export type { StorageInterface };
-export { Iterate, withIterate };
+export { Iterate, IterateProvider };
 export default Iterate;

--- a/src/iterate.tsx
+++ b/src/iterate.tsx
@@ -5,6 +5,7 @@ import { TriggerTypes, Version } from './constants';
 import {
   reducer,
   reset,
+  setCompanyAuthToken,
   setEventTraits,
   setLastUpdated,
   setPreview,
@@ -14,6 +15,7 @@ import {
   showSurvey,
 } from './redux';
 import type {
+  EdgeInsets,
   EmbedContext,
   EventTraits,
   Response,
@@ -22,37 +24,67 @@ import type {
   Question,
   UserTraits,
 } from './types';
-import Storage, { Keys } from './storage';
+import Storage, { Keys, StorageInterface } from './storage';
+import SafeArea from './safearea';
 
 export const store = createStore(reducer);
 export type Dispatch = typeof store.dispatch;
 
+export type EventData = { eventName: string; eventTraits?: EventTraits };
+
 class Iterate {
   api?: ApiClient;
-  eventQueue: string[] = [];
+  apiKey?: string;
+  eventQueue: EventData[] = [];
   initialized: boolean = false;
+  initializedIdentify: boolean = false;
+  initializedSendEvent: boolean = false;
   onResponseCallback?: (Response: Response, Question: Question) => void;
 
-  // Indicate that the client is fully initialized and ready to send events
-  init = () => {
+  // Minimal initialization that is expected to be called on app boot
+  init = ({
+    apiKey,
+    safeArea,
+    storage,
+  }: {
+    apiKey: string;
+    safeArea: () => EdgeInsets;
+    storage: StorageInterface;
+  }) => {
+    this.apiKey = apiKey;
+    SafeArea.provider = safeArea;
+    Storage.provider = storage;
     this.initialized = true;
-    this.eventQueue.forEach((event) => {
-      this.sendEvent(event);
-    });
   };
 
-  configure = (apiKey: string) => {
-    this.api = new ApiClient(apiKey);
+  // Lazily initialize dependencies for identify
+  initIdentify = async () => {
+    if (!this.initialized) {
+      throw 'Error calling Iterate.identify(). Make sure you call Iterate.init() before calling identify, see README for details';
+    }
+
+    if (!this.initializedIdentify) {
+      const userTraits: {} | null = await Storage.getItem(
+        Keys.userTraits
+      ).catch((err) => {
+        throw `Error getting user attributes from secure storage: ${err}`;
+      });
+
+      // Initialize the user traits
+      if (userTraits != null) {
+        store.dispatch(setUserTraits(userTraits));
+      }
+
+      this.initializedIdentify = true;
+    }
   };
 
-  identify = (userTraits?: UserTraits, eventTraits?: EventTraits) => {
+  identify = async (userTraits: UserTraits) => {
+    await this.initIdentify();
+
     if (userTraits != null) {
       store.dispatch(setUserTraits(userTraits));
       Storage.setItem(Keys.userTraits, userTraits);
-    }
-
-    if (eventTraits != null) {
-      store.dispatch(setEventTraits(eventTraits));
     }
   };
 
@@ -73,13 +105,51 @@ class Iterate {
     store.dispatch(reset());
   };
 
-  sendEvent = (eventName: string) => {
-    // If the client hasn't been initialized yet (e.g. loading async data from local storage)
-    // then queue up the events. Shouldn't have to wait more than a few milliseconds or less
-    if (this.initialized !== true) {
-      this.eventQueue.push(eventName);
-      return;
+  // Lazily initialize dependencies for sendEvent
+  initSendEvent = async (): Promise<void | undefined> => {
+    if (!this.initialized) {
+      throw 'Error calling Iterate.sendEvent(). Make sure you call Iterate.init() before calling sendEvent, see README for details';
     }
+
+    if (!this.initializedSendEvent) {
+      // Initialize company api key and api
+      if (this.apiKey == null) {
+        throw 'Error sending event to Iterate: missing api key. Make sure you call Iterate.init() before calling sendEvent, see README for details';
+      }
+      this.api = new ApiClient(this.apiKey);
+      store.dispatch(setCompanyAuthToken(this.apiKey));
+
+      // Initialize authToken
+      const authToken: string | null = await Storage.getItem(
+        Keys.authToken
+      ).catch((err) => {
+        throw `Error getting authToken from secure storage: ${err}`;
+      });
+      if (authToken != null) {
+        this.api = new ApiClient(authToken);
+        store.dispatch(setUserAuthToken(authToken));
+      }
+
+      // Initialize last updated timestamp
+      const lastUpdated: string | null = await Storage.getItem(
+        Keys.lastUpdated
+      ).catch((err) => {
+        throw `Error getting last updated timestamp from secure storage: ${err}`;
+      });
+      if (lastUpdated != null) {
+        store.dispatch(setLastUpdated(parseInt(lastUpdated, 10)));
+      }
+
+      // Initialize user traits
+      await this.initIdentify();
+
+      this.initializedSendEvent = true;
+    }
+  };
+
+  sendEvent = async (eventName: string, eventTraits?: EventTraits) => {
+    // Lazily initialize dependencies for sendEvent
+    await this.initSendEvent();
 
     const state = store.getState();
 
@@ -139,6 +209,14 @@ class Iterate {
       }
 
       if (response != null && response.survey != null) {
+        // Generate a unique id (current timestamp) for this survey display so we ensure we associate
+        // the correct event traits with it
+        const responseId = new Date().getTime();
+
+        if (eventTraits != null) {
+          store.dispatch(setEventTraits(eventTraits, responseId));
+        }
+
         // If the survey has a timer trigger, wait that number of seconds before showing the survey
         if (
           response.triggers != null &&
@@ -147,10 +225,10 @@ class Iterate {
         ) {
           const survey = response.survey;
           setTimeout(() => {
-            this.dispatchShowSurveyOrPrompt(survey);
+            this.dispatchShowSurveyOrPrompt(survey, responseId);
           }, (response.triggers[0].options.seconds || 0) * 1000);
         } else {
-          this.dispatchShowSurveyOrPrompt(response.survey);
+          this.dispatchShowSurveyOrPrompt(response.survey, responseId);
         }
       }
 
@@ -158,11 +236,11 @@ class Iterate {
     });
   };
 
-  dispatchShowSurveyOrPrompt(survey: Survey) {
+  dispatchShowSurveyOrPrompt(survey: Survey, responseId: number) {
     if (survey.prompt != null) {
-      store.dispatch(showPrompt(survey));
+      store.dispatch(showPrompt(survey, responseId));
     } else {
-      store.dispatch(showSurvey(survey));
+      store.dispatch(showSurvey(survey, responseId));
     }
 
     if (this.api == null) {

--- a/src/redux.tsx
+++ b/src/redux.tsx
@@ -1,3 +1,4 @@
+import type { EdgeInsets } from './types';
 import type { EventTraits, Survey, UserTraits } from './types';
 
 // State
@@ -8,6 +9,7 @@ export type State = {
   lastUpdated?: number;
   preview?: boolean;
   previewSurveyId?: string;
+  safeAreaInsets: EdgeInsets;
   showSurvey: boolean;
   showPrompt: boolean;
   survey?: Survey;
@@ -22,6 +24,7 @@ const INITIAL_STATE = {
   lastUpdated: undefined,
   preview: false,
   previewSurveyId: undefined,
+  safeAreaInsets: { top: 0, left: 0, right: 0, bottom: 0 },
   showSurvey: false,
   showPrompt: false,
   survey: undefined,
@@ -37,6 +40,7 @@ type Action =
   | SetEventTraits
   | SetLastUpdated
   | SetPreview
+  | SetSafeAreaInsets
   | SetUserAuthToken
   | SetUserTraits
   | ShowPromptAction
@@ -48,6 +52,10 @@ type SetCompanyAuthToken = { type: 'SET_COMPANY_AUTH_TOKEN'; token: string };
 type SetEventTraits = { type: 'SET_EVENT_TRAITS'; traits: EventTraits };
 type SetLastUpdated = { type: 'SET_LAST_UPDATED'; lastUpdated: number };
 type SetPreview = { type: 'SET_PREVIEW'; enabled: boolean; surveyId?: string };
+type SetSafeAreaInsets = {
+  type: 'SET_SAFE_AREA_INSETS';
+  safeAreaInsets: EdgeInsets;
+};
 type SetUserAuthToken = { type: 'SET_USER_AUTH_TOKEN'; token: string };
 type SetUserTraits = { type: 'SET_USER_TRAITS'; traits: UserTraits };
 type ShowPromptAction = { type: 'SHOW_PROMPT'; survey: Survey };
@@ -79,6 +87,13 @@ export const setPreview = (
   type: 'SET_PREVIEW',
   enabled,
   surveyId,
+});
+
+export const setSafeAreaInsets = (
+  safeAreaInsets: EdgeInsets
+): SetSafeAreaInsets => ({
+  type: 'SET_SAFE_AREA_INSETS',
+  safeAreaInsets,
 });
 
 export const setUserAuthToken = (token: string): SetUserAuthToken => ({
@@ -135,6 +150,11 @@ export const reducer = (state: State = INITIAL_STATE, action: Action) => {
         ...state,
         preview: action.enabled,
         previewSurveyId: action.surveyId,
+      };
+    case 'SET_SAFE_AREA_INSETS':
+      return {
+        ...state,
+        safeAreaInsets: action.safeAreaInsets,
       };
     case 'SET_USER_AUTH_TOKEN':
       return {

--- a/src/redux.tsx
+++ b/src/redux.tsx
@@ -1,11 +1,12 @@
 import type { EdgeInsets } from './types';
-import type { EventTraits, Survey, UserTraits } from './types';
+import type { EventTraits, EventTraitsMap, Survey, UserTraits } from './types';
 
 // State
 export type State = {
   companyAuthToken?: string;
   dismissed: boolean;
-  eventTraits?: EventTraits;
+  displayedSurveyResponseId?: number;
+  eventTraits: EventTraitsMap;
   lastUpdated?: number;
   preview?: boolean;
   previewSurveyId?: string;
@@ -20,6 +21,7 @@ export type State = {
 const INITIAL_STATE = {
   companyAuthToken: undefined,
   dismissed: false,
+  displayedSurveyResponseId: undefined,
   eventTraits: {},
   lastUpdated: undefined,
   preview: false,
@@ -49,7 +51,11 @@ type Action =
 type DismissAction = { type: 'DISMISS' };
 type ResetAction = { type: 'RESET' };
 type SetCompanyAuthToken = { type: 'SET_COMPANY_AUTH_TOKEN'; token: string };
-type SetEventTraits = { type: 'SET_EVENT_TRAITS'; traits: EventTraits };
+type SetEventTraits = {
+  type: 'SET_EVENT_TRAITS';
+  responseId: number;
+  traits: EventTraits;
+};
 type SetLastUpdated = { type: 'SET_LAST_UPDATED'; lastUpdated: number };
 type SetPreview = { type: 'SET_PREVIEW'; enabled: boolean; surveyId?: string };
 type SetSafeAreaInsets = {
@@ -58,8 +64,16 @@ type SetSafeAreaInsets = {
 };
 type SetUserAuthToken = { type: 'SET_USER_AUTH_TOKEN'; token: string };
 type SetUserTraits = { type: 'SET_USER_TRAITS'; traits: UserTraits };
-type ShowPromptAction = { type: 'SHOW_PROMPT'; survey: Survey };
-type ShowSurveyAction = { type: 'SHOW_SURVEY'; survey: Survey };
+type ShowPromptAction = {
+  type: 'SHOW_PROMPT';
+  responseId?: number;
+  survey: Survey;
+};
+type ShowSurveyAction = {
+  type: 'SHOW_SURVEY';
+  responseId?: number;
+  survey: Survey;
+};
 
 export const dismiss = (): DismissAction => ({ type: 'DISMISS' });
 
@@ -70,8 +84,12 @@ export const setCompanyAuthToken = (token: string): SetCompanyAuthToken => ({
   token,
 });
 
-export const setEventTraits = (traits: EventTraits): SetEventTraits => ({
+export const setEventTraits = (
+  traits: EventTraits,
+  responseId: number
+): SetEventTraits => ({
   type: 'SET_EVENT_TRAITS',
+  responseId,
   traits,
 });
 
@@ -106,13 +124,21 @@ export const setUserTraits = (traits: UserTraits): SetUserTraits => ({
   traits,
 });
 
-export const showPrompt = (survey: Survey): ShowPromptAction => ({
+export const showPrompt = (
+  survey: Survey,
+  responseId?: number
+): ShowPromptAction => ({
   type: 'SHOW_PROMPT',
+  responseId,
   survey,
 });
 
-export const showSurvey = (survey: Survey): ShowSurveyAction => ({
+export const showSurvey = (
+  survey: Survey,
+  responseId?: number
+): ShowSurveyAction => ({
   type: 'SHOW_SURVEY',
+  responseId,
   survey,
 });
 
@@ -123,6 +149,8 @@ export const reducer = (state: State = INITIAL_STATE, action: Action) => {
       return {
         ...state,
         dismissed: true,
+        displayedSurveyResponseId: undefined,
+        eventTraits: {},
         showSurvey: false,
         showPrompt: false,
       };
@@ -138,7 +166,9 @@ export const reducer = (state: State = INITIAL_STATE, action: Action) => {
     case 'SET_EVENT_TRAITS':
       return {
         ...state,
-        eventTraits: action.traits,
+        eventTraits: {
+          [`${action.responseId}`]: action.traits,
+        },
       };
     case 'SET_LAST_UPDATED':
       return {
@@ -169,12 +199,20 @@ export const reducer = (state: State = INITIAL_STATE, action: Action) => {
     case 'SHOW_PROMPT':
       return {
         ...state,
+        displayedSurveyResponseId:
+          action.responseId != null
+            ? action.responseId
+            : state.displayedSurveyResponseId,
         survey: action.survey,
         showPrompt: true,
       };
     case 'SHOW_SURVEY':
       return {
         ...state,
+        displayedSurveyResponseId:
+          action.responseId != null
+            ? action.responseId
+            : state.displayedSurveyResponseId,
         survey: action.survey,
         showSurvey: true,
         showPrompt: false,

--- a/src/safearea.tsx
+++ b/src/safearea.tsx
@@ -1,0 +1,8 @@
+import type { EdgeInsets } from './types';
+
+class SafeArea {
+  // A user-provided safe area provider
+  provider?: () => EdgeInsets;
+}
+
+export default new SafeArea();

--- a/src/storage.tsx
+++ b/src/storage.tsx
@@ -15,11 +15,11 @@ const KeyPrefix = 'com.iteratehq.';
 
 class Storage {
   // A user-provided secure storage
-  storageProvider?: StorageInterface;
+  provider?: StorageInterface;
 
   // Remove all stored items
   clear = async () => {
-    return this.storageFacility().then(async (storage) => {
+    return this.storageProvider().then(async (storage) => {
       for (const [, value] of Object.entries(Keys)) {
         storage.removeItem(`${KeyPrefix}${value}`);
       }
@@ -27,7 +27,7 @@ class Storage {
   };
 
   getItem = async (key: string) => {
-    return this.storageFacility().then(async (storage) => {
+    return this.storageProvider().then(async (storage) => {
       const result = await storage.getItem(`${KeyPrefix}${key}`);
       if (result != null) {
         return JSON.parse(result).value;
@@ -36,15 +36,15 @@ class Storage {
   };
 
   setItem = async (key: string, value: any) => {
-    return this.storageFacility().then(
+    return this.storageProvider().then(
       async (storage) =>
         await storage.setItem(`${KeyPrefix}${key}`, JSON.stringify({ value }))
     );
   };
 
-  storageFacility = async (): Promise<StorageInterface> => {
-    if (this.storageProvider != null) {
-      return this.storageProvider;
+  storageProvider = async (): Promise<StorageInterface> => {
+    if (this.provider != null) {
+      return this.provider;
     }
 
     throw 'Error initializing Iterate: missing storage. You must provide a storage facility, see README for details';

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -48,6 +48,13 @@ export type UserTraitsContext = { [key: string]: UserTraitValue };
 
 export type UserTraits = UserTraitsContext;
 
+export type EdgeInsets = {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+};
+
 export type Survey = {
   color?: string;
   company_id: string;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -23,6 +23,11 @@ export type EventTraitsContext = { [key: string]: EventTraitValue };
 
 export type EventTraits = EventTraitsContext;
 
+// A map from the response id to the events associated with that response
+export type EventTraitsMap = {
+  [key: string]: EventTraits;
+};
+
 export type TargetingContext = {
   frequency?: Frequency;
   survey_id?: string;


### PR DESCRIPTION
This change will require a major version bump to 2.x

There are a few improvements in this PR
1. Changes from the withIterate high-order component to the `<IterateProvider>` component
2. `Iterate.init(...)` is now required to be called before any other methods
3. The user now provides their own safe area
4. Changed the API for sending event properties from happening in the Identify method, to the sendEvent method
5. All initialization is now lazy-loaded to maximize app boot performance
6. Additional error handling