### PR TITLE
fix: reset interaction events when Iterate is reset

### DIFF
--- a/src/interaction-events.tsx
+++ b/src/interaction-events.tsx
@@ -94,4 +94,9 @@ class InteractionEventCallbacks {
   ) => {};
 }
 
+export const resetInteractionEventCallbacks = () => {
+  Callbacks.onEvent = (_type, _data) => {};
+  Callbacks.onResponse = (_type, _data, _survey) => {};
+};
+
 export const Callbacks = new InteractionEventCallbacks();

--- a/src/iterate.tsx
+++ b/src/iterate.tsx
@@ -7,6 +7,7 @@ import {
   InteractionEventTypeValues,
   InteractionEventData,
   InteractionEvents,
+  resetInteractionEventCallbacks,
 } from './interaction-events';
 import {
   reducer,
@@ -119,6 +120,9 @@ class Iterate {
   // Reset all stored user data. Commonly called on logout so apps can support
   // multiple user accounts
   reset = () => {
+    // Reset the interaction events. Surveys opened with a delay, might otherwise
+    // lead to callbacks
+    resetInteractionEventCallbacks();
     // Only clear the storage if it has been initialized. This allows the reset
     // method to be called before Init, giving consumers of the SDK more flexibility
     if (Storage.provider != null) {
@@ -235,7 +239,7 @@ class Iterate {
         Storage.setItem(Keys.lastUpdated, lastUpdated);
       }
 
-      if (response != null && response.survey != null) {
+      if (response.survey != null) {
         // Generate a unique id (current timestamp) for this survey display so we ensure we associate
         // the correct event traits with it
         const responseId = new Date().getTime();


### PR DESCRIPTION
Iterate.reset should be called after logout. If a survey is scheduled to be shown not immediately, but after a delay, the notification callback might be shown after logout, even if Iterate has already been reset. 
Resetting the callbacks (onEvent and onResponse) to their initial state avoids having to check Iterate initialisation state or having to reset the callbacks in addition to calling Iterate.reset