### PR TITLE
fix: allow file:// requests in webview

### DIFF
--- a/src/components/Survey.tsx
+++ b/src/components/Survey.tsx
@@ -208,7 +208,8 @@ const SurveyView: (Props: Props) => JSX.Element = ({
               onLoadEnd={() => setIsLoading(false)}
               onShouldStartLoadWithRequest={(request) => {
                 if (
-                  request.url.startsWith(Iterate.api?.apiHost ?? DefaultHost)
+                  request.url.startsWith(Iterate.api?.apiHost ?? DefaultHost) ||
+                  request.url.startsWith('file://')
                 ) {
                   return true;
                 } else {


### PR DESCRIPTION
In one recent change, we added the `onShouldStartLoadWithRequest` to the webview component in order to open non-Iterate URLs in a new browser window (to enable external links in surveys). In another change, we changed the base URL of the webview to `file:///` and started loading the survey page in a separate request and then populating the webview with an HTML string, to enable the use of local font files.

These two changes conflict, as the file:// request is not on the Iterate domain, so we were attempting to open it in a browser window. This fix allows file:// URLs to open in the webview itself.