### PR TITLE
Add dependabot.yml for production deps only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
## Summary
- Adds `dependabot.yml` configured to only create version update PRs for production dependencies
- DevDependency updates (like handlebars via conventional-changelog-writer) generate noise without security value since they never run in production

## Note
This controls Dependabot **version update PRs** only — security alerts still need to be dismissed manually. Existing handlebars alerts (CVE-2026-33941, -33938, -33940) should be dismissed in the GitHub UI as "not used in production."

🤖 Generated with [Claude Code](https://claude.com/claude-code)