### PR TITLE
fix(deps): pin patched versions to resolve 4 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
     "tar": "^7.5.11",
     "minimatch": "^9.0.7",
     "fast-xml-parser": "^5.5.6",
+    "fast-xml-builder": "^1.1.7",
+    "fast-uri": "^3.1.2",
+    "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "undici": "^6.24.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,9 +931,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-systemjs@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.0"
+"@babel/plugin-transform-modules-systemjs@npm:^7.29.4":
+  version: 7.29.4
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.4"
   dependencies:
     "@babel/helper-module-transforms": ^7.28.6
     "@babel/helper-plugin-utils": ^7.28.6
@@ -941,7 +941,7 @@ __metadata:
     "@babel/traverse": ^7.29.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 36fd7bcd694549effdbdf733c32f0c9dbadea052316ff5e0830b07482a60c8ff1ee79850efff05e8046c4b99c241832f2c5267e0ae7c721c531c8ef12930c4b9
+  checksum: d9cbb30669077756048af990a08ad1ba149785c336024affa49848dc4ffc5948bfaaf52d90bbec711a1f320e19e2c60182dbeff40d81cc5b9a09a87919abe07d
   languageName: node
   linkType: hard
 
@@ -6138,19 +6138,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: daab0efd3548cc53d0db38ecc764d125773f8bd70c34552ff21abdc6530f26fa4cb1771f944222ca5e61a0a1a85d01a104848ff88c61736de445d97bd616ea7e
+"fast-uri@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 73a6e1b04e6fcf7a09ed93316e72d643ef177d26969973784690708612141f2c2f74657120bab75bf5bbc26bfd535a32c90a8c3bc50aca50584cf01f98815afe
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "fast-xml-builder@npm:1.1.4"
+"fast-xml-builder@npm:^1.1.7":
+  version: 1.2.0
+  resolution: "fast-xml-builder@npm:1.2.0"
   dependencies:
-    path-expression-matcher: ^1.1.3
-  checksum: 90b019ed6f52cb30342a58d4bf8726a7723b4110cb9c0fd3fa2031e87506e8b18740fd349472926c9e2925d22ca6637b6d46a20eda537473cf63366970db4d7b
+    path-expression-matcher: ^1.5.0
+    xml-naming: ^0.1.0
+  checksum: 3bf38faf65dee87d213b4fc096b57141d68248d6c7e64f24879fce646f2e681f1ad2669e17eebc75abc8c6147a1c84001c1b8c4d9cb3c0fea21650b74c230c7d
   languageName: node
   linkType: hard
 
@@ -9856,17 +9857,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-expression-matcher@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "path-expression-matcher@npm:1.1.3"
-  checksum: 9b045e857fd812a8c36f987fae44e49f5843b25408f69e7776540fbb0b59e7f5484aff6cf8b98ee45425ae36a979dfe557a24e385127a9a1aaa85953811eb4c9
-  languageName: node
-  linkType: hard
-
 "path-expression-matcher@npm:^1.2.0":
   version: 1.2.0
   resolution: "path-expression-matcher@npm:1.2.0"
   checksum: 2811aab3269c288893aef09e5127124d3c434bfc7e1352fea6b7dd81ed20260001b072ff60bdcaaa393d50a4333725290dbad47bb612d95f5448e499b4ac887f
+  languageName: node
+  linkType: hard
+
+"path-expression-matcher@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "path-expression-matcher@npm:1.5.0"
+  checksum: 52f0491a88f728f2eefb83a5c4f84f1185a8572e34ba41a72f88e270d5796c966ec1fe78e978599c490ccac0656a4cc55d75485538393873d32a4ef096a8dda6
   languageName: node
   linkType: hard
 
@@ -12305,6 +12306,13 @@ __metadata:
   dependencies:
     is-wsl: ^3.1.0
   checksum: de4c92187e04c3c27b4478f410a02e81c351dc85efa3447bf1666f34fc80baacd890a6698ec91995631714086992036013286aea3d77e6974020d40a08e00aec
+  languageName: node
+  linkType: hard
+
+"xml-naming@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "xml-naming@npm:0.1.0"
+  checksum: 8d1b5b84430f688a95f02ae1e13557d481242eed6de945569c444a6ec1553a0065afe39a1536aeffee3a787cb3cf99432e61d9fbbaa6d8d64555d550e6b4b13d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Pins three transitive devDependencies to patched versions via the existing `resolutions` block, resolving 4 open GitHub Dependabot alerts.

## Vulnerabilities resolved

| Alert | CVE | Package | From → To | Reaches via |
|-------|-----|---------|-----------|-------------|
| [#282](https://github.com/iteratehq/react-native-iterate/security/dependabot/282) | CVE-2026-44665 | fast-xml-builder | 1.1.4 → 1.2.0 | `@react-native-community/cli-platform-apple` → `fast-xml-parser` |
| [#283](https://github.com/iteratehq/react-native-iterate/security/dependabot/283) | CVE-2026-6321 | fast-uri | 3.1.0 → 3.1.2 | `@commitlint/cli` → `ajv@8` |
| [#284](https://github.com/iteratehq/react-native-iterate/security/dependabot/284) | CVE-2026-6322 | fast-uri | 3.1.0 → 3.1.2 | same as above |
| [#285](https://github.com/iteratehq/react-native-iterate/security/dependabot/285) | CVE-2026-44728 | @babel/plugin-transform-modules-systemjs | 7.29.0 → 7.29.4 | `@babel/preset-env` |

## Exploitability assessment

All four are transitive **devDependencies** — none ship in the published SDK. Even at the build-tool layer they're not exploitable in our usage:

- **fast-xml-builder**: vuln is attribute injection during XML building. Only used by RN CLI to generate Xcode/Android project files (no attacker-controlled input).
- **fast-uri**: URI normalization issues. ajv is used at build time by commitlint, not for validating user-supplied URLs.
- **@babel/plugin-transform-modules-systemjs**: advisory explicitly says "Users that only compile trusted code are not impacted." We only compile our own SDK and do not use the `modules: "systemjs"` option.

Pinning to clean up the alerts is the lowest-friction path and follows the existing pattern in this repo's `resolutions` block (already pins `qs`, `tar`, `undici`, `fast-xml-parser` for security).

## Test plan

- [x] `yarn install` — regenerated yarn.lock cleanly
- [x] `yarn typecheck` — green
- [x] `yarn lint` — green
- [x] `yarn test` — green
- [x] `yarn prepare` (bob build) — green
