### PR TITLE
fix(deps): pin shell-quote to ^1.8.4 (CVE-2026-9277)

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "fast-xml-builder": "^1.1.7",
     "fast-uri": "^3.1.2",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
-    "undici": "^6.24.0"
+    "undici": "^6.24.0",
+    "shell-quote": "^1.8.4"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11053,10 +11053,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 550dd84e677f8915eb013d43689c80bb114860649ec5298eb978f40b8f3d4bc4ccb072b82c094eb3548dc587144bb3965a8676f0d685c1cf4c40b5dc27166242
+"shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 082dc836baa8ade01144ee3068af487ea45ba570ea6ab13a5eddc11ab16a976b8857b51ef2caf7dc9a1e173ff0aea685b8f78b4f6f5a0a1ef24c7b17c51350e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Pins `shell-quote` to `^1.8.4` via the `resolutions` block to resolve **CVE-2026-9277** (CRITICAL, CVSS 8.1) — GitHub Dependabot alert #287.

## Vulnerability
`shell-quote` ≤ 1.8.3 does not escape line terminators in the `.op` field of object tokens passed to `quote()`. A literal newline passes through unescaped and POSIX shells treat it as a command separator → shell command injection in callers that build object tokens from untrusted input.

## Exposure assessment
Transitive dev/build-only dependency, pulled in by:
- `launch-editor@2.13.1` (Metro dev server's editor opener)
- `react-devtools-core@6.1.5`

Neither is bundled into the published SDK (`lib/`), and neither is fed attacker-controlled input. **Not exploitable in our usage** — but pinned anyway, consistent with the existing `fast-xml-parser`/`fast-uri`/`babel-systemjs` resolutions precedent. Patch bump (1.8.3 -> 1.8.4) satisfies both consumers' ranges (`^1.6.1`, `^1.8.3`).
