### PR TITLE
fix: correctly inject the auth token

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
   },
   "jest": {
     "preset": "react-native",
+    "coverageProvider": "v8",
     "modulePathIgnorePatterns": [
       "<rootDir>/examples/",
       "<rootDir>/lib/"

--- a/src/__tests__/survey-auth-token.test.tsx
+++ b/src/__tests__/survey-auth-token.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Regression test for iteratehq/react-native-iterate#320.
+ *
+ * The survey WebView must deliver the auth_token to the page. The page reads it from
+ * window.location.search on every API request, so the token has to be present in the
+ * document URL natively. We load the page as static HTML (file:// origin, so bundled
+ * custom fonts resolve) and carry the query string in the WebView's baseUrl.
+ *
+ * The previous approach loaded the HTML with a blank baseUrl and tried to re-add the
+ * query string after load via injectedJavaScript (history.pushState) — WebKit rejects
+ * pushState on the opaque origin, so the token was dropped and every answer was recorded
+ * against a new anonymous user.
+ */
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { WebView } from 'react-native-webview';
+
+// Render the survey component directly with props (bypass redux connect).
+jest.mock('react-redux', () => ({
+  connect: () => (Component: unknown) => Component,
+}));
+
+// SafeAreaProvider only renders children once it has measured a frame, which
+// never happens under the test renderer; this mock renders children immediately.
+jest.mock('react-native-safe-area-context', () => {
+  const react = require('react');
+  const passthrough = (props: { children?: unknown }) =>
+    react.createElement(react.Fragment, null, props.children);
+  return {
+    SafeAreaProvider: passthrough,
+    SafeAreaView: passthrough,
+    useSafeAreaInsets: () => ({ top: 0, left: 0, right: 0, bottom: 0 }),
+  };
+});
+
+jest.mock('react-native-webview', () => {
+  const react = require('react');
+  return {
+    WebView: (props: Record<string, unknown>) =>
+      react.createElement('WebView', props),
+  };
+});
+
+import Survey from '../components/Survey';
+import Iterate from '../iterate';
+import type { Survey as SurveyType } from '../types';
+
+const survey: SurveyType = {
+  company_id: 'company-1',
+  id: 'survey-1',
+  title: 'Test survey',
+};
+
+const USER_TOKEN = 'user-auth-token-abc123';
+
+const baseProps = {
+  eventTraits: {},
+  onDismiss: () => {},
+  presentationStyle: 'pageSheet' as const,
+  survey,
+  userAuthToken: USER_TOKEN,
+};
+
+const renderSurvey = async () => {
+  let tree!: TestRenderer.ReactTestRenderer;
+  const SurveyComponent = Survey as unknown as React.ComponentType<
+    typeof baseProps
+  >;
+  await act(async () => {
+    tree = TestRenderer.create(<SurveyComponent {...baseProps} />);
+  });
+  // Let the fetched-HTML promise resolve so the WebView renders.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return tree;
+};
+
+const getWebViewSource = (tree: TestRenderer.ReactTestRenderer) => {
+  const webView = tree.root.findByType(WebView as never);
+  return webView.props.source as { uri?: string; html?: string; baseUrl?: string };
+};
+
+describe('Survey auth token delivery (#320)', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    Iterate.buttonFont = undefined;
+    Iterate.surveyTextFont = undefined;
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ text: () => Promise.resolve('<html></html>') })
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Iterate.buttonFont = undefined;
+    Iterate.surveyTextFont = undefined;
+  });
+
+  it('carries the auth_token in a file:// baseUrl so it reaches window.location.search', async () => {
+    const tree = await renderSurvey();
+    const source = getWebViewSource(tree);
+
+    // Static HTML load (file:// origin), not a direct URL load.
+    expect(source.html).toBeDefined();
+    expect(source.uri).toBeUndefined();
+
+    // The query string — including the auth_token — is carried in the baseUrl.
+    expect(source.baseUrl).toBeDefined();
+    expect(source.baseUrl).toMatch(/^file:\/\/\//);
+    expect(source.baseUrl).toContain(`auth_token=${USER_TOKEN}`);
+  });
+
+  it('still carries the auth_token when a custom font is configured', async () => {
+    Iterate.buttonFont = {
+      filename: 'WorkSans-Regular.ttf',
+      postscriptName: 'WorkSans-Regular',
+    };
+
+    const tree = await renderSurvey();
+    const source = getWebViewSource(tree);
+
+    expect(source.html).toBeDefined();
+    expect(source.baseUrl).toContain(`auth_token=${USER_TOKEN}`);
+    expect(source.baseUrl).toContain('buttonFontPath=');
+  });
+});

--- a/src/components/Survey.tsx
+++ b/src/components/Survey.tsx
@@ -137,13 +137,22 @@ const SurveyView: (Props: Props) => React.ReactElement = ({
     );
   }
 
-  const url = `${DefaultHost}/${survey?.company_id}/${
-    survey?.id
-  }/mobile?${params.join('&')}`;
+  const queryString = params.join('&');
+  const url = `${DefaultHost}/${survey?.company_id}/${survey?.id}/mobile?${queryString}`;
 
-  // In order to access assets in the app bundle (e.g. fonts), we need to load the HTML for the survey page in
-  // a separate request and provide it to the webview, so that the webview's base URL is the location of the
-  // app bundle in the local filesystem.
+  // The survey page reads the auth_token (and other params) from window.location.search on every API
+  // request. We load the page as static HTML with a file:// base URL so bundled custom fonts resolve, and
+  // we carry the query string in that base URL so window.location.search is populated natively when the
+  // page boots. We used to load the HTML with a blank base URL and re-add the query string after load via
+  // injectedJavaScript (history.pushState), but WebKit rejects pushState on the resulting opaque origin, so
+  // the token never reached the page and every answer was recorded against a new anonymous user (issue #320).
+  const baseUrl =
+    Platform.OS === 'android'
+      ? `file:///?${queryString}`
+      : `file:///index.html?${queryString}`;
+
+  // Fetch the survey page HTML and hand it to the WebView as a static string (rather than loading the URL
+  // directly) so the WebView's origin is file:// — required for bundled fonts to resolve from the app bundle.
   useEffect(() => {
     if (survey != null) {
       setIsLoading(true);
@@ -203,11 +212,6 @@ const SurveyView: (Props: Props) => React.ReactElement = ({
         : (backgroundColor = Colors.Grey);
   }
 
-  // Only do this if we haven't already
-  const addQueryParamScript = `if (!window.location.search) {
-    window.history.pushState('', '', '?${params.join('&')}');
-  }`;
-
   return (
     <View>
       <Modal
@@ -250,15 +254,12 @@ const SurveyView: (Props: Props) => React.ReactElement = ({
                 }
               }}
               originWhitelist={['file://']}
-              // Once the webview has loaded the static HTML for the page, window.location.href will be a file:/// url.
-              // Append the auth token to the URL as a query parameter so the page can use it for API requests
-              injectedJavaScript={addQueryParamScript}
               source={{
                 html,
-                // On iOS, a blank baseUrl parameter here results in window.location.href being a file:/// url pointing
-                // local location of the bundle. On Android, we need to provide a baseUrl or window.location.href will be
-                // about:blank.
-                baseUrl: Platform.OS === 'android' ? 'file:///' : '',
+                // The query string (auth_token etc.) is carried here so it is present in
+                // window.location.search when the page boots. The file:// origin lets bundled
+                // custom fonts resolve from the app bundle.
+                baseUrl,
               }}
               style={{ backgroundColor: backgroundColor }}
             />


### PR DESCRIPTION
This uses a more reliable method to make sure the auth_token is available as a query param when the webview loads so auth is handled correctly (keeping the long comments so we have a bit of context in the future)

Fixes #320 